### PR TITLE
Add docker tag on docker build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,17 @@
 #!groovy
 
-node('!master && amazon-linux-64bit-generic') {
+node('!master && amazon-linux-64bit-generic && docker') {
     checkout scm
 
+    stage 'parameters'
+    sh 'git rev-parse --short HEAD | tee version'
+    env.VERSION = 'commit_' + readFile('version').trim()
+
     stage name: 'Build slate image'
-    sh "docker build -t dev.bambora.com ."
+    sh "docker build -t dev.bambora.com:${env.VERSION} ."
 
     stage name: 'Build static web content'
-    sh "docker run -v \"\$PWD\"/build:/usr/src/app/build dev.bambora.com static"
+    sh "docker run -v \"\$PWD\"/build:/usr/src/app/build dev.bambora.com:${env.VERSION} static"
 
     if (env.BRANCH_NAME == "master") {
         stage name: 'Publish to S3'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-node('!master && amazon-linux-64bit-generic && docker') {
+node('docker-concurrent') {
     checkout scm
 
     stage 'parameters'


### PR DESCRIPTION
In order to avoid concurrency issues when building on a Jenkins agent with many executors.
